### PR TITLE
Scrollable mobile navigation

### DIFF
--- a/assets/styles/layouts/_header.scss
+++ b/assets/styles/layouts/_header.scss
@@ -87,7 +87,9 @@ nav {
       .main {
         display: flex;
         flex-flow: row nowrap;
-        justify-content: center;
+        justify-content: initial;
+        max-width: 100vw;
+        overflow: auto;
       }
 
       .abteilungen {
@@ -95,6 +97,8 @@ nav {
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
+        max-height: 70vh;
+        overflow: auto;
         li {
           flex-grow: 1;
           width: 33%;
@@ -113,6 +117,7 @@ nav {
         }
       }
       .brand-logo-wrapper {
+        max-height: 20vh;
         height:130px;
         .brand-logo {
           .logo {

--- a/templates/header.php
+++ b/templates/header.php
@@ -52,10 +52,6 @@
         <img class="logo shadowed" src="<?php echo get_stylesheet_directory_uri(); ?>/assets/images/tgv.logo.svg">
       </a>
     </div>
-    <div>
-      <a style="width:90%;" href="mailto:info@tgveintrachtbeilstein.de" class="waves-effect waves-light btn grey darken-3"><i class="material-icons left">email</i>info@tgveintrachtbeilstein.de</a>
-      <a style="width:90%;" href="tel:+4970625753" class="waves-effect waves-light btn grey darken-3"><i class="material-icons left">phone</i>+49 (0) 7062 - 5753</a>
-    </div>
     <ul class="abteilungen">
       <?php
         $type = 'abteilung';


### PR DESCRIPTION
Die Abteilungen in der mobile-navigation scrollbar machen, sodass auch bei kleinerem viewport alle Abteilungen erreicht werden können.